### PR TITLE
Grab Blend Mode from ExtGState

### DIFF
--- a/lib/pdf/inspector/extgstate.rb
+++ b/lib/pdf/inspector/extgstate.rb
@@ -12,7 +12,8 @@ module PDF
           @extgstates << {
                           :opacity => stream[:ca],
                           :stroke_opacity => stream[:CA],
-                          :soft_mask => stream[:SMask]
+                          :soft_mask => stream[:SMask],
+                          :blend_mode => stream[:BM]
                           }
         end
       end


### PR DESCRIPTION
I'm working on a [Blend Mode patch](https://github.com/prawnpdf/prawn/pull/910) and need ExtGState to pull back BM for the new specs.