### PR TITLE
allow pdf-reader version 2.0

### DIFF
--- a/pdf-inspector.gemspec
+++ b/pdf-inspector.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
                 'dnelson77@gmail.com', 'greenberg@entryway.net',
                 'jimmy@deefa.com']
   spec.licenses = %w[PRAWN GPL-2.0 GPL-3.0]
-  spec.add_dependency('pdf-reader', '~>1.0')
+  spec.add_dependency('pdf-reader', '>=1.0', '< 3.0')
   spec.add_development_dependency('bundler')
   spec.add_development_dependency('rake')
   spec.add_development_dependency('rspec')


### PR DESCRIPTION
pdf-reader v2.x removed the old pre-1.0 API, but it's fully compatible with the 1.0 API that pdf-inspector uses