### PR TITLE
Add reader_opts (currently only useful for password-protected files) to PDF::Reader.open call

### DIFF
--- a/lib/pdf/inspector.rb
+++ b/lib/pdf/inspector.rb
@@ -9,12 +9,12 @@ require 'stringio'
 
 module PDF
   class Inspector
-    def self.analyze(output, *args, &block)
+    def self.analyze(output, *args, **reader_opts, &block)
       if output.is_a?(String)
         output = StringIO.new(output)
       end
       obs = new(*args, &block)
-      PDF::Reader.open(output) do |reader|
+      PDF::Reader.open(output, reader_opts || {}) do |reader|
         reader.pages.each do |page|
           page.walk(obs)
         end


### PR DESCRIPTION
I had to use this gem to analyze some password-protected documents and it required these small changes.

The corresponding code in [pdf-reader](https://github.com/yob/pdf-reader) is [here](https://github.com/yob/pdf-reader/blob/8548ce483f79dc215d7648b85cc42dfd01b52302/lib/pdf/reader.rb#L113) and [here](https://github.com/yob/pdf-reader/blob/26ea423c42f673d4579bcd3c1cf63523e8ddc079/lib/pdf/reader/object_hash.rb#L42).

Would you mind adding this code to the gem?