### PR TITLE
Migrate CI to GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,72 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: "6 20 * * 6"
+
+jobs:
+  code-style:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.1.0
+      - name: Gems cache
+        uses: actions/cache@v2
+        with:
+          path: ~/gems
+          key: gems-3.0.0-${{ hashFiles('*.gemspec', 'Gemfile') }}-${{ github.sha }}
+          restore-keys: |
+            gems-3.0.0-${{ hashFiles('*.gemspec', 'Gemfile') }}-
+            gems-3.0.0-
+      - name: Install dependencies
+        run: |
+          gem install bundler
+          bundle config path ~/gems
+          bundle install --jobs 4 --retry 3
+      - name: Check code style
+        run: bundle exec rake rubocop
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby:
+          - "2.5.0"
+          - "2.5"
+          - "2.6.0"
+          - "2.6"
+          - "2.7.0"
+          - "2.7"
+          - "3.0.0"
+          - "3.0"
+          - "3.1.0"
+          - "3.1"
+          - ruby-head
+          - jruby-9.2
+          - jruby-9.3
+    steps:
+      - uses: actions/checkout@v1
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+      - name: Gems cache
+        uses: actions/cache@v2
+        with:
+          path: ~/gems
+          key: gems-${{ matrix.ruby }}-${{ hashFiles('*.gemspec', 'Gemfile') }}-${{ github.sha }}
+          restore-keys: |
+            gems-${{ matrix.ruby }}-${{ hashFiles('*.gemspec', 'Gemfile') }}-
+            gems-${{ matrix.ruby }}-
+      - name: Install dependencies
+        run: |
+          gem install bundler
+          bundle config path ~/gems
+          bundle install --jobs 4 --retry 3
+      - name: Run tests
+        run: bundle exec rake spec

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.1.0
+          ruby-version: 3.0.0
       - name: Gems cache
         uses: actions/cache@v2
         with:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,9 +1,7 @@
 AllCops:
-  Include:
-    - '**/Rakefile'
-    - '*.gemspec'
   Exclude:
     - 'pkg/**/*'
+  TargetRubyVersion: 2.5
 
 Metrics/BlockLength:
   Exclude:

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
-source "https://rubygems.org"
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
 
 gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'bundler'
 Bundler.setup
 
@@ -6,7 +8,7 @@ require 'rspec/core/rake_task'
 require 'rubygems/package_task'
 require 'rubocop/rake_task'
 
-task default: [:spec, :rubocop]
+task default: %i[spec rubocop]
 
 desc 'Run all rspec files'
 RSpec::Core::RakeTask.new('spec') do |c|

--- a/lib/pdf/inspector.rb
+++ b/lib/pdf/inspector.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rubygems'
 require 'pdf/reader'
 require 'pdf/inspector/text'

--- a/lib/pdf/inspector/extgstate.rb
+++ b/lib/pdf/inspector/extgstate.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module PDF
   class Inspector
     class ExtGState < Inspector

--- a/lib/pdf/inspector/graphics.rb
+++ b/lib/pdf/inspector/graphics.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module PDF
   class Inspector
     module Graphics

--- a/lib/pdf/inspector/page.rb
+++ b/lib/pdf/inspector/page.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'forwardable'
 
 module PDF

--- a/lib/pdf/inspector/text.rb
+++ b/lib/pdf/inspector/text.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module PDF
   class Inspector
     class Text < Inspector
@@ -32,8 +34,8 @@ module PDF
         @font_settings << { name: @fonts[params[0]], size: params[1] }
       end
 
-      def move_text_position(tx, ty)
-        @positions << [tx, ty]
+      def move_text_position(transx, transy)
+        @positions << [transx, transy]
       end
 
       def show_text(*params)

--- a/lib/pdf/inspector/xobject.rb
+++ b/lib/pdf/inspector/xobject.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module PDF
   class Inspector
     class XObject < Inspector

--- a/pdf-inspector.gemspec
+++ b/pdf-inspector.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Gem::Specification.new do |spec|
   spec.name = 'pdf-inspector'
   spec.version = '1.3.0'
@@ -20,21 +22,25 @@ Gem::Specification.new do |spec|
                 'dnelson77@gmail.com', 'greenberg@entryway.net',
                 'jimmy@deefa.com']
   spec.licenses = %w[PRAWN GPL-2.0 GPL-3.0]
+  spec.required_ruby_version = '>= 2.5'
+
   spec.add_dependency('pdf-reader', '>=1.0', '< 3.0.a')
+
   spec.add_development_dependency('bundler')
   spec.add_development_dependency('rake')
   spec.add_development_dependency('rspec')
   spec.add_development_dependency('rubocop', '~> 0.46')
   spec.add_development_dependency('yard')
-  spec.description = <<END_DESC
-This library provides a number of PDF::Reader[0] based tools for use in testing
-PDF output.  Presently, the primary purpose of this tool is to support the
-tests found in Prawn[1], a pure Ruby PDF generation library.
 
-However, it may be useful to others, so we have made it available as a gem in
-its own right.
+  spec.description = <<~END_DESC
+    This library provides a number of PDF::Reader[0] based tools for use in testing
+    PDF output.  Presently, the primary purpose of this tool is to support the
+    tests found in Prawn[1], a pure Ruby PDF generation library.
 
-[0] https://github.com/yob/pdf-reader
-[1] https://github.com/prawnpdf/prawn
-END_DESC
+    However, it may be useful to others, so we have made it available as a gem in
+    its own right.
+
+    [0] https://github.com/yob/pdf-reader
+    [1] https://github.com/prawnpdf/prawn
+  END_DESC
 end

--- a/spec/pdf_inspector_text_spec.rb
+++ b/spec/pdf_inspector_text_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'spec_helper'
 
 describe 'PDF::Inspector::Text' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,4 @@
-# encoding: utf-8
+# frozen_string_literal: true
 
 puts "PDF::Inspector specs: Running on Ruby Version: #{RUBY_VERSION}"
 


### PR DESCRIPTION
Adds a CI configuration based on the prawnpdf/prawn config.

Also:

1. Gets Rubocop running with existing config on code files
2. Addresses a few lints to get Rubocop green

@pointlessone As a baseline it would be good to get this PR merged, so CI runs on this library.