### PR TITLE
Add prawn-dev

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,8 +36,6 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - "2.5.0"
-          - "2.5"
           - "2.6.0"
           - "2.6"
           - "2.7.0"
@@ -47,7 +45,6 @@ jobs:
           - "3.1.0"
           - "3.1"
           - ruby-head
-          - jruby-9.2
           - jruby-9.3
     steps:
       - uses: actions/checkout@v1

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,5 @@
-AllCops:
-  Exclude:
-    - 'pkg/**/*'
-  TargetRubyVersion: 2.5
+inherit_gem:
+  prawn-dev: rubocop.yml
 
 Metrics/BlockLength:
   Exclude:

--- a/Rakefile
+++ b/Rakefile
@@ -1,12 +1,7 @@
 # frozen_string_literal: true
 
-require 'bundler'
-Bundler.setup
-
-require 'rake'
-require 'rspec/core/rake_task'
-require 'rubygems/package_task'
-require 'rubocop/rake_task'
+GEMSPEC = File.expand_path('pdf-inspector.gemspec', __dir__)
+require 'prawn/dev/tasks'
 
 task default: %i[spec rubocop]
 

--- a/lib/pdf/inspector/extgstate.rb
+++ b/lib/pdf/inspector/extgstate.rb
@@ -6,6 +6,7 @@ module PDF
       attr_accessor :extgstates
 
       def initialize
+        super
         @extgstates = []
       end
 

--- a/lib/pdf/inspector/graphics.rb
+++ b/lib/pdf/inspector/graphics.rb
@@ -7,6 +7,7 @@ module PDF
         attr_accessor :points, :widths
 
         def initialize
+          super
           @points = []
           @widths = []
         end
@@ -28,6 +29,7 @@ module PDF
         attr_reader :rectangles
 
         def initialize
+          super
           @rectangles = []
         end
 
@@ -44,6 +46,7 @@ module PDF
         attr_reader :coords
 
         def initialize
+          super
           @coords = []
         end
 
@@ -57,10 +60,15 @@ module PDF
       end
 
       class Color < Inspector
-        attr_reader :stroke_color, :fill_color, :stroke_color_count,
-                    :fill_color_count, :stroke_color_space_count, :color_space
+        attr_reader :stroke_color,
+          :fill_color,
+          :stroke_color_count,
+          :fill_color_count,
+          :stroke_color_space_count,
+          :color_space
 
         def initialize
+          super
           @stroke_color_count = 0
           @fill_color_count = 0
           @stroke_color_space_count = { DeviceCMYK: 0, DeviceRGB: 0 }
@@ -86,6 +94,7 @@ module PDF
         attr_reader :stroke_dash, :stroke_dash_count
 
         def initialize
+          super
           @stroke_dash_count = 0
         end
 
@@ -99,6 +108,7 @@ module PDF
         attr_reader :cap_style, :cap_style_count
 
         def initialize
+          super
           @cap_style_count = 0
         end
 
@@ -112,6 +122,7 @@ module PDF
         attr_reader :join_style, :join_style_count
 
         def initialize
+          super
           @join_style_count = 0
         end
 
@@ -125,6 +136,7 @@ module PDF
         attr_reader :matrices
 
         def initialize
+          super
           @matrices = []
         end
 
@@ -137,7 +149,8 @@ module PDF
         attr_reader :save_graphics_state_count, :restore_graphics_state_count
 
         def initialize
-          @save_graphics_state_count    = 0
+          super
+          @save_graphics_state_count = 0
           @restore_graphics_state_count = 0
         end
 

--- a/lib/pdf/inspector/page.rb
+++ b/lib/pdf/inspector/page.rb
@@ -12,11 +12,12 @@ module PDF
       def_delegators :@state, :set_text_font_and_size
 
       def initialize
+        super
         @pages = []
       end
 
       def page=(page)
-        @pages << { size: page.attributes[:MediaBox][-2..-1], strings: [] }
+        @pages << { size: page.attributes[:MediaBox][-2..], strings: [] }
         @state = PDF::Reader::PageState.new(page)
       end
 

--- a/lib/pdf/inspector/text.rb
+++ b/lib/pdf/inspector/text.rb
@@ -9,6 +9,7 @@ module PDF
       attr_accessor :horizontal_text_scaling
 
       def initialize
+        super
         @font_settings = []
         @fonts = {}
         @font_objects = {}
@@ -24,7 +25,7 @@ module PDF
       def page=(page)
         @state = PDF::Reader::PageState.new(page)
         page.fonts.each do |label, stream|
-          @fonts[label]        = stream[:BaseFont]
+          @fonts[label] = stream[:BaseFont]
           @font_objects[label] = PDF::Reader::Font.new(page.objects, stream)
         end
       end

--- a/lib/pdf/inspector/xobject.rb
+++ b/lib/pdf/inspector/xobject.rb
@@ -6,6 +6,7 @@ module PDF
       attr_accessor :page_xobjects, :xobject_streams
 
       def initialize
+        super
         @page_xobjects = []
         @xobject_streams = {}
       end

--- a/pdf-inspector.gemspec
+++ b/pdf-inspector.gemspec
@@ -13,23 +13,27 @@ Gem::Specification.new do |spec|
   end
 
   spec.files = Dir.glob('{lib}/**/**/*') +
-               %w[CHANGELOG.md README.md COPYING LICENSE GPLv2 GPLv3]
+    %w[CHANGELOG.md README.md COPYING LICENSE GPLv2 GPLv3]
   spec.extra_rdoc_files = %w[CHANGELOG.md README.md]
   spec.rdoc_options += %w[--title PDF::Inspector --main README.md -q]
-  spec.authors = ['Gregory Brown', 'Brad Ediger', 'Daniel Nelson',
-                  'Jonathan Greenberg', 'James Healy']
-  spec.email = ['gregory.t.brown@gmail.com', 'brad@bradediger.com',
-                'dnelson77@gmail.com', 'greenberg@entryway.net',
-                'jimmy@deefa.com']
+  spec.authors = [
+    'Gregory Brown', 'Brad Ediger', 'Daniel Nelson',
+    'Jonathan Greenberg', 'James Healy'
+  ]
+  spec.email = [
+    'gregory.t.brown@gmail.com', 'brad@bradediger.com',
+    'dnelson77@gmail.com', 'greenberg@entryway.net',
+    'jimmy@deefa.com'
+  ]
   spec.licenses = %w[PRAWN GPL-2.0 GPL-3.0]
-  spec.required_ruby_version = '>= 2.5'
+  spec.required_ruby_version = '>= 2.6'
 
   spec.add_dependency('pdf-reader', '>=1.0', '< 3.0.a')
 
   spec.add_development_dependency('bundler')
+  spec.add_development_dependency('prawn-dev', '~> 0.3.0')
   spec.add_development_dependency('rake')
   spec.add_development_dependency('rspec')
-  spec.add_development_dependency('rubocop', '~> 0.46')
   spec.add_development_dependency('yard')
 
   spec.description = <<~END_DESC

--- a/pdf-inspector.gemspec
+++ b/pdf-inspector.gemspec
@@ -30,11 +30,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency('pdf-reader', '>=1.0', '< 3.0.a')
 
-  spec.add_development_dependency('bundler')
   spec.add_development_dependency('prawn-dev', '~> 0.3.0')
-  spec.add_development_dependency('rake')
-  spec.add_development_dependency('rspec')
-  spec.add_development_dependency('yard')
 
   spec.description = <<~END_DESC
     This library provides a number of PDF::Reader[0] based tools for use in testing

--- a/spec/pdf_inspector_text_spec.rb
+++ b/spec/pdf_inspector_text_spec.rb
@@ -6,7 +6,7 @@ describe 'PDF::Inspector::Text' do
   describe '.analyze_file' do
     let(:contents) do
       PDF::Inspector::Text.analyze_file(
-        "#{File.dirname(__FILE__)}/fixtures/text.pdf"
+        File.join(__dir__, 'fixtures', 'text.pdf')
       )
     end
 

--- a/spec/pdf_inspector_text_spec.rb
+++ b/spec/pdf_inspector_text_spec.rb
@@ -3,10 +3,10 @@
 require_relative 'spec_helper'
 
 describe 'PDF::Inspector::Text' do
-  context '.analyze_file' do
+  describe '.analyze_file' do
     let(:contents) do
       PDF::Inspector::Text.analyze_file(
-        File.dirname(__FILE__) + '/fixtures/text.pdf'
+        "#{File.dirname(__FILE__)}/fixtures/text.pdf"
       )
     end
 


### PR DESCRIPTION
- Updates Rubocop to use prawn-dev
- Sets minimum Ruby version to 2.6
- Removes incompatible Rubies from CI
- Fixes a few lints