### PR TITLE
Remove unnecessary `require: 'pdf/inspector'` from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Or put this in your Gemfile, if you use [Bundler][2]:
 
 ```ruby
 group :test do
-  gem 'pdf-inspector', require: "pdf/inspector"
+  gem 'pdf-inspector'
 end
 ```
 


### PR DESCRIPTION
Bundler automatically requires `lib/pdf/inspector.rb` based on the gem name `pdf-inspector`, so there's no need to specify it explicitly as an option.

You can confirm this behavior with a simple example like the one below:

```ruby
require 'bundler/inline'

gemfile do
  source 'https://rubygems.org'
  gem 'pdf-inspector'
end

puts defined?(PDF::Inspector::Text) #=> constant
```